### PR TITLE
DOCS: Added new gitignore rules for ignoring secret files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.p12
 *.p7b
 *.p7c
+ft_crypt.sh
 secrets/
 
 ############################ Binary and Blob Files ############################


### PR DESCRIPTION
.txt for docker secrets.
.cer, .cert, .crt, pfx, p12, p7b, p7c (acording to Isi suggestion)