### PR TITLE
FIX: Fixed broken Prettier due to invalid plugins declaration.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -11,7 +11,6 @@
 	"printWidth": 80,
 	"arrowParens": "always",
 	"endOfLine": "lf",
-	"plugins": ["prettier-plugin-tailwindcss"],
 
 	"overrides": [
 		{


### PR DESCRIPTION
- VSCode prints an error for Prettier (PROBLEMS tab): Error: Cannot find module 'prettier' from '/home/marondon/Documents/Github/transcendence2.0'
- VSCOde also shows Prettier status (down-right corner of VSCode window) as broken (in red).
- It's due to invalid Prettier plugin: "plugins": ["prettier-plugin-tailwindcss"], So just remove that line from .prettierrc file and now Prettier should work again

Since it's a node package and **NOT** a VSCode extension, then others can have issues with their VSCode.
So maybe, (just for now), we remove this line and later we decide if everyone should install it.

If someone later works with TailwindCSS (_front-end stuff_), then it can install it in his node packages (package.json).
You can follow the instructions [here](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).

This PR solves the [Prettier issue](https://github.com/marcorondong/transcendence2.0/issues/168)