### PR TITLE
[FIX] Fixed broken Prettier (mr_0504_FEAT-Prettier-TailwindCSS-pluging)

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -11,7 +11,6 @@
 	"printWidth": 80,
 	"arrowParens": "always",
 	"endOfLine": "lf",
-	"plugins": ["prettier-plugin-tailwindcss"],
 
 	"overrides": [
 		{


### PR DESCRIPTION
This PR does the following:
1. It **removes** conflicting line in `.prettierrc` file.
	1. If the Node pkg is not installed in the local computer, it **breaks** Prettier.
	2. Note that the line is a `devDependency` for Front-End, so others don't need it but it's **affecting everyone**.
2. It changes **invalid** `package-lock.json` file.
	1. It seems that Isi placed his TICTACTOE `package-lock.json` service file in the repo's root, and then pushed it.
	2. It **shouldn't** be like that. Services' `package-lock.json` go into their respective service folder, not in root's repo (unless we agreed something else).
	3. The version in this PR is the "correct" one. Only with the packages that appear in `package.json`located in root folder, and with the correct names (e.g: "transcendence2.0"" instead of "isi_tictactoe_version2").