### PR TITLE
[CHORE]: Added more patterns to gitignore (mr_0511_CHORE-Updating-gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,13 +89,17 @@ wheels/
 **/env/
 **/.venv/
 **/.env/
+**/myenv/
 
 ############################# Databases & Storage #############################
+**/database/
+**/databases/
 db.sqlite3
 *.db
 *.sqlite
 *.sqlite3
 **/media/
+*-journal
 
 ################################ Logs & Debug #################################
 *.log
@@ -109,8 +113,13 @@ lerna-debug.log*
 ############################# Backup & Old Files ##############################
 *.bak
 **/bak/
+**/*-bak/
+*.backup
+**/backup/
+**/*-backup/
 *.old
 **/old/
+**/*-old/
 
 ###################### IDE & Editor Files ######################
 ### VS Code ###


### PR DESCRIPTION
Added more patterns to ignore 'backup' files/folders, 'old' files/folders, 'journal' files and 'virtual environment' folders
- Any file which name ends with '-journal' will be ignored. (E.g: they get created when database structure is modified). (We should NOT push databases).
- Any folder which name is 'database' 'databses' will be ignored. (We should NOT push databases).
- Any file that ends with '.bak' '.backup' '.old' will be ignored.
- Any folder which name is 'bak' 'backup' 'old' will be ignored.
- Any folder which name ends with '-bak' '-backup' '-old' will be ignored.
- Any folder which name is 'myenv' will be ignored. (Filip has one for his CLI python virtual environment).