### PR TITLE
[FIX]: Included USERS yml file into Main/Root yml file (mr_0512_FIX-Main-dockercomposeyml-USERS-inclusion)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,7 +115,7 @@ services:
     networks:
       - Transcendence2.0
     depends_on:
-    - chat_db
+      - chat_db
     restart: always
 
   chat_db:
@@ -140,9 +140,10 @@ services:
     restart: always
 
 include:
-  - ./monitoring/monitoring-docker-compose.yml
-  - ./frontend/docker-compose.yml
   - ./microservices/auth_api/docker-compose.yml
+  - ./frontend/docker-compose.yml
+  - ./monitoring/monitoring-docker-compose.yml
+  - ./microservices/users/docker-compose.yml
 
 networks:
   Transcendence2.0:


### PR DESCRIPTION
Added the docker-compose,yml file from USERS service to the include directive of the MAIN docker-compose.yml.
So now it's included and called by the main/root docker-compose.yml so it runs when using (in root) Make or docker compose up.

Tested it by running `Make` and it worked fine.

P.D:
We'll need to address later the folowing things:
1. We need to create a `README.md` with instructions to run the project (which address to browse, files to place, commands to run, etc).
2. Specify which `.env` file to use for pong. The encrypted one, or the one from Discord.
3. Check if the file `monitoring/secrets/slack_webhook.txt` can be dinamically generated, or if we should encrypt it.
4. Agreed that when after running the project, we **must** clean the secrets files (`.env` and `.txt`) so we can spot what will be missing if someone tries to run the project. (E.g: I couldn't run the project easily because I need to copy some files, and mabe others didn't have that issue because they already copied them. But we should try to make everything more "automated").