### PR TITLE
[DOCS]: Removed duplicated gitignore files and removed duplicated directives

### DIFF
--- a/microservices/chat_db/.gitignore
+++ b/microservices/chat_db/.gitignore
@@ -1,3 +1,0 @@
-node_modules
-# Keep environment variables out of version control
-.env

--- a/microservices/pong_db/.gitignore
+++ b/microservices/pong_db/.gitignore
@@ -1,3 +1,0 @@
-node_modules
-# Keep environment variables out of version control
-.env

--- a/microservices/ssg/ai/.gitignore
+++ b/microservices/ssg/ai/.gitignore
@@ -1,8 +1,6 @@
-*.js
 *.cjs
 
 # Playwright
-node_modules/
 /test-results/
 /playwright-report/
 /blob-report/

--- a/microservices/tictactoe_db/.gitignore
+++ b/microservices/tictactoe_db/.gitignore
@@ -1,3 +1,0 @@
-node_modules
-# Keep environment variables out of version control
-.env


### PR DESCRIPTION

# 📝 Documentation Pull Request

---

## 📄 Description

Removed duplicated `.gitignore` files and duplicated ignores.
Later, we can implement the remaining ignores from AI `.gitignore` into our main gitignore.

---

## 📦 Affected Modules

`.gitignore` of CHAT_DB, PONG_DB, TICTACTOE and AI Service.
Note that THe *_DB use Prisma, and Prisma autogenerates a `.gitignore` to ignore the automatically-created `.env` file and `node_modules` folder it populates.

---

## 🔍 Scope

- [X] gitignore files.
- [ ] README updates.
- [ ] Code comments / docstrings.
- [ ] Wiki / external guides.
- [ ] API docs / Swagger.
