### PR TITLE
[FIX]: Fixed some spelling mistakes

### DIFF
--- a/monitoring/grafana/custom-dashboards/endpoints_availability.json
+++ b/monitoring/grafana/custom-dashboards/endpoints_availability.json
@@ -1,331 +1,331 @@
 {
-	"dashboard": {
-		"annotations": {
-			"list": [
-				{
-					"builtIn": 1,
-					"datasource": {
-						"type": "grafana",
-						"uid": "-- Grafana --"
-					},
-					"enable": true,
-					"hide": true,
-					"iconColor": "rgba(0, 211, 255, 1)",
-					"name": "Annotations & Alerts",
-					"type": "dashboard"
-				}
-			]
-		},
-		"editable": true,
-		"fiscalYearStartMonth": 0,
-		"graphTooltip": 0,
-		"id": null,
-		"links": [],
-		"panels": [
-			{
-				"datasource": {
-					"type": "prometheus"
-				},
-				"fieldConfig": {
-					"defaults": {
-						"color": {
-							"mode": "continuous-RdYlGr"
-						},
-						"mappings": [],
-						"max": 1,
-						"min": 0,
-						"thresholds": {
-							"mode": "absolute",
-							"steps": [
-								{
-									"color": "green"
-								},
-								{
-									"color": "red",
-									"value": 80
-								}
-							]
-						},
-						"unit": "bool_yes_no"
-					},
-					"overrides": []
-				},
-				"gridPos": {
-					"h": 6,
-					"w": 24,
-					"x": 0,
-					"y": 0
-				},
-				"id": 2,
-				"options": {
-					"colorMode": "background",
-					"graphMode": "area",
-					"justifyMode": "auto",
-					"orientation": "auto",
-					"percentChangeColorMode": "standard",
-					"reduceOptions": {
-						"calcs": ["lastNotNull"],
-						"fields": "",
-						"values": false
-					},
-					"showPercentChange": false,
-					"textMode": "value_and_name",
-					"wideLayout": true
-				},
-				"pluginVersion": "11.6.0",
-				"targets": [
-					{
-						"disableTextWrap": false,
-						"editorMode": "builder",
-						"expr": "probe_success",
-						"fullMetaSearch": false,
-						"includeNullMetadata": true,
-						"legendFormat": "{{instance}}",
-						"range": true,
-						"refId": "A",
-						"useBackend": false
-					}
-				],
-				"title": "Probe success",
-				"type": "stat"
-			},
-			{
-				"datasource": {
-					"type": "prometheus"
-				},
-				"fieldConfig": {
-					"defaults": {
-						"color": {
-							"mode": "continuous-BlYlRd"
-						},
-						"mappings": [],
-						"max": 600,
-						"min": 0,
-						"thresholds": {
-							"mode": "absolute",
-							"steps": [
-								{
-									"color": "green"
-								},
-								{
-									"color": "red",
-									"value": 80
-								}
-							]
-						}
-					},
-					"overrides": []
-				},
-				"gridPos": {
-					"h": 6,
-					"w": 24,
-					"x": 0,
-					"y": 6
-				},
-				"id": 3,
-				"options": {
-					"colorMode": "background",
-					"graphMode": "area",
-					"justifyMode": "auto",
-					"orientation": "auto",
-					"percentChangeColorMode": "standard",
-					"reduceOptions": {
-						"calcs": ["lastNotNull"],
-						"fields": "",
-						"values": false
-					},
-					"showPercentChange": false,
-					"textMode": "auto",
-					"wideLayout": true
-				},
-				"pluginVersion": "11.6.0",
-				"targets": [
-					{
-						"editorMode": "builder",
-						"expr": "probe_http_status_code",
-						"legendFormat": "{{instance}}",
-						"range": true,
-						"refId": "A"
-					}
-				],
-				"title": "Probe status code",
-				"type": "stat"
-			},
-			{
-				"datasource": {
-					"type": "prometheus"
-				},
-				"fieldConfig": {
-					"defaults": {
-						"color": {
-							"mode": "thresholds"
-						},
-						"mappings": [],
-						"thresholds": {
-							"mode": "absolute",
-							"steps": [
-								{
-									"color": "green"
-								},
-								{
-									"color": "red",
-									"value": 80
-								}
-							]
-						},
-						"unit": "bool_yes_no"
-					},
-					"overrides": []
-				},
-				"gridPos": {
-					"h": 7,
-					"w": 4,
-					"x": 0,
-					"y": 12
-				},
-				"id": 1,
-				"options": {
-					"colorMode": "background",
-					"graphMode": "none",
-					"justifyMode": "auto",
-					"orientation": "auto",
-					"percentChangeColorMode": "standard",
-					"reduceOptions": {
-						"calcs": ["lastNotNull"],
-						"fields": "",
-						"values": false
-					},
-					"showPercentChange": false,
-					"textMode": "auto",
-					"wideLayout": true
-				},
-				"pluginVersion": "11.6.0",
-				"targets": [
-					{
-						"datasource": {
-							"type": "prometheus"
-						},
-						"disableTextWrap": false,
-						"editorMode": "builder",
-						"expr": "blackbox_exporter_config_last_reload_successful{instance=\"blackbox-exporter:9115\"}",
-						"fullMetaSearch": false,
-						"includeNullMetadata": true,
-						"legendFormat": "__auto",
-						"range": true,
-						"refId": "A",
-						"useBackend": false
-					}
-				],
-				"title": "Blackbox config loaded",
-				"type": "stat"
-			},
-			{
-				"datasource": {
-					"type": "prometheus"
-				},
-				"fieldConfig": {
-					"defaults": {
-						"color": {
-							"mode": "palette-classic"
-						},
-						"custom": {
-							"axisBorderShow": false,
-							"axisCenteredZero": false,
-							"axisColorMode": "text",
-							"axisLabel": "",
-							"axisPlacement": "auto",
-							"barAlignment": 0,
-							"barWidthFactor": 0.6,
-							"drawStyle": "line",
-							"fillOpacity": 0,
-							"gradientMode": "none",
-							"hideFrom": {
-								"legend": false,
-								"tooltip": false,
-								"viz": false
-							},
-							"insertNulls": false,
-							"lineInterpolation": "linear",
-							"lineWidth": 1,
-							"pointSize": 5,
-							"scaleDistribution": {
-								"type": "linear"
-							},
-							"showPoints": "auto",
-							"spanNulls": false,
-							"stacking": {
-								"group": "A",
-								"mode": "none"
-							},
-							"thresholdsStyle": {
-								"mode": "off"
-							}
-						},
-						"mappings": [],
-						"thresholds": {
-							"mode": "absolute",
-							"steps": [
-								{
-									"color": "green"
-								},
-								{
-									"color": "red",
-									"value": 80
-								}
-							]
-						},
-						"unit": "s"
-					},
-					"overrides": []
-				},
-				"gridPos": {
-					"h": 7,
-					"w": 20,
-					"x": 4,
-					"y": 12
-				},
-				"id": 4,
-				"options": {
-					"legend": {
-						"calcs": ["min", "max", "mean"],
-						"displayMode": "table",
-						"placement": "bottom",
-						"showLegend": true
-					},
-					"tooltip": {
-						"hideZeros": false,
-						"mode": "single",
-						"sort": "none"
-					}
-				},
-				"pluginVersion": "11.6.0",
-				"targets": [
-					{
-						"editorMode": "code",
-						"expr": "avg_over_time(probe_duration_seconds[5m])",
-						"legendFormat": "{{instance}}",
-						"range": true,
-						"refId": "A"
-					}
-				],
-				"title": "Average respose time",
-				"type": "timeseries"
-			}
-		],
-		"preload": false,
-		"schemaVersion": 41,
-		"tags": ["endpoints_availability"],
-		"templating": {
-			"list": []
-		},
-		"time": {
-			"from": "now-6h",
-			"to": "now"
-		},
-		"timepicker": {},
-		"timezone": "browser",
-		"title": "Endpoints availability",
-		"uid": null
-	},
-	"overwrite": true
+  "dashboard": {
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": null,
+    "links": [],
+    "panels": [
+      {
+        "datasource": {
+          "type": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "continuous-RdYlGr"
+            },
+            "mappings": [],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "bool_yes_no"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 6,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 2,
+        "options": {
+          "colorMode": "background",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "percentChangeColorMode": "standard",
+          "reduceOptions": {
+            "calcs": ["lastNotNull"],
+            "fields": "",
+            "values": false
+          },
+          "showPercentChange": false,
+          "textMode": "value_and_name",
+          "wideLayout": true
+        },
+        "pluginVersion": "11.6.0",
+        "targets": [
+          {
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "expr": "probe_success",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "legendFormat": "{{instance}}",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Probe success",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "continuous-BlYlRd"
+            },
+            "mappings": [],
+            "max": 600,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 6,
+          "w": 24,
+          "x": 0,
+          "y": 6
+        },
+        "id": 3,
+        "options": {
+          "colorMode": "background",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "percentChangeColorMode": "standard",
+          "reduceOptions": {
+            "calcs": ["lastNotNull"],
+            "fields": "",
+            "values": false
+          },
+          "showPercentChange": false,
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "pluginVersion": "11.6.0",
+        "targets": [
+          {
+            "editorMode": "builder",
+            "expr": "probe_http_status_code",
+            "legendFormat": "{{instance}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Probe status code",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "bool_yes_no"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 4,
+          "x": 0,
+          "y": 12
+        },
+        "id": 1,
+        "options": {
+          "colorMode": "background",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "percentChangeColorMode": "standard",
+          "reduceOptions": {
+            "calcs": ["lastNotNull"],
+            "fields": "",
+            "values": false
+          },
+          "showPercentChange": false,
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "pluginVersion": "11.6.0",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus"
+            },
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "expr": "blackbox_exporter_config_last_reload_successful{instance=\"blackbox-exporter:9115\"}",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Blackbox config loaded",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 20,
+          "x": 4,
+          "y": 12
+        },
+        "id": 4,
+        "options": {
+          "legend": {
+            "calcs": ["min", "max", "mean"],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.6.0",
+        "targets": [
+          {
+            "editorMode": "code",
+            "expr": "avg_over_time(probe_duration_seconds[5m])",
+            "legendFormat": "{{instance}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Average response time",
+        "type": "timeseries"
+      }
+    ],
+    "preload": false,
+    "schemaVersion": 41,
+    "tags": ["endpoints_availability"],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "browser",
+    "title": "Endpoints availability",
+    "uid": null
+  },
+  "overwrite": true
 }

--- a/monitoring/grafana/custom-dashboards/network_monitor.json
+++ b/monitoring/grafana/custom-dashboards/network_monitor.json
@@ -1,1161 +1,1161 @@
 {
-	"dashboard": {
-		"annotations": {
-			"list": [
-				{
-					"builtIn": 1,
-					"datasource": {
-						"type": "grafana",
-						"uid": "-- Grafana --"
-					},
-					"enable": true,
-					"hide": true,
-					"iconColor": "rgba(0, 211, 255, 1)",
-					"name": "Annotations & Alerts",
-					"type": "dashboard"
-				}
-			]
-		},
-		"editable": true,
-		"fiscalYearStartMonth": 0,
-		"graphTooltip": 0,
-		"id": null,
-		"links": [],
-		"panels": [
-			{
-				"datasource": {
-					"type": "prometheus"
-				},
-				"fieldConfig": {
-					"defaults": {
-						"color": {
-							"mode": "palette-classic"
-						},
-						"custom": {
-							"axisBorderShow": false,
-							"axisCenteredZero": false,
-							"axisColorMode": "text",
-							"axisLabel": "",
-							"axisPlacement": "auto",
-							"barAlignment": 0,
-							"barWidthFactor": 0.6,
-							"drawStyle": "line",
-							"fillOpacity": 0,
-							"gradientMode": "none",
-							"hideFrom": {
-								"legend": false,
-								"tooltip": false,
-								"viz": false
-							},
-							"insertNulls": false,
-							"lineInterpolation": "linear",
-							"lineWidth": 1,
-							"pointSize": 5,
-							"scaleDistribution": {
-								"type": "linear"
-							},
-							"showPoints": "auto",
-							"spanNulls": false,
-							"stacking": {
-								"group": "A",
-								"mode": "none"
-							},
-							"thresholdsStyle": {
-								"mode": "off"
-							}
-						},
-						"mappings": [],
-						"thresholds": {
-							"mode": "absolute",
-							"steps": [
-								{
-									"color": "green"
-								},
-								{
-									"color": "red",
-									"value": 80
-								}
-							]
-						}
-					},
-					"overrides": []
-				},
-				"gridPos": {
-					"h": 8,
-					"w": 12,
-					"x": 0,
-					"y": 0
-				},
-				"id": 12,
-				"options": {
-					"legend": {
-						"calcs": [],
-						"displayMode": "list",
-						"placement": "bottom",
-						"showLegend": true
-					},
-					"tooltip": {
-						"hideZeros": false,
-						"mode": "single",
-						"sort": "none"
-					}
-				},
-				"pluginVersion": "11.6.0",
-				"targets": [
-					{
-						"disableTextWrap": false,
-						"editorMode": "builder",
-						"expr": "irate(node_netstat_Tcp_ActiveOpens[5m])",
-						"fullMetaSearch": false,
-						"includeNullMetadata": true,
-						"legendFormat": "TCP active connections",
-						"range": true,
-						"refId": "A",
-						"useBackend": false
-					},
-					{
-						"datasource": {
-							"type": "prometheus"
-						},
-						"disableTextWrap": false,
-						"editorMode": "builder",
-						"expr": "irate(node_netstat_Tcp_PassiveOpens[5m])",
-						"fullMetaSearch": false,
-						"hide": false,
-						"includeNullMetadata": true,
-						"instant": false,
-						"legendFormat": "TCP passive connections",
-						"range": true,
-						"refId": "B",
-						"useBackend": false
-					}
-				],
-				"title": "TCP active/passive connections",
-				"type": "timeseries"
-			},
-			{
-				"datasource": {
-					"type": "prometheus"
-				},
-				"fieldConfig": {
-					"defaults": {
-						"color": {
-							"mode": "palette-classic"
-						},
-						"custom": {
-							"axisBorderShow": false,
-							"axisCenteredZero": false,
-							"axisColorMode": "text",
-							"axisLabel": "",
-							"axisPlacement": "auto",
-							"barAlignment": 0,
-							"barWidthFactor": 0.6,
-							"drawStyle": "line",
-							"fillOpacity": 0,
-							"gradientMode": "none",
-							"hideFrom": {
-								"legend": false,
-								"tooltip": false,
-								"viz": false
-							},
-							"insertNulls": false,
-							"lineInterpolation": "linear",
-							"lineWidth": 1,
-							"pointSize": 5,
-							"scaleDistribution": {
-								"type": "linear"
-							},
-							"showPoints": "auto",
-							"spanNulls": false,
-							"stacking": {
-								"group": "A",
-								"mode": "none"
-							},
-							"thresholdsStyle": {
-								"mode": "off"
-							}
-						},
-						"mappings": [],
-						"thresholds": {
-							"mode": "absolute",
-							"steps": [
-								{
-									"color": "green"
-								},
-								{
-									"color": "red",
-									"value": 80
-								}
-							]
-						}
-					},
-					"overrides": []
-				},
-				"gridPos": {
-					"h": 8,
-					"w": 12,
-					"x": 12,
-					"y": 0
-				},
-				"id": 11,
-				"options": {
-					"legend": {
-						"calcs": ["min", "max", "mean"],
-						"displayMode": "list",
-						"placement": "bottom",
-						"showLegend": true
-					},
-					"tooltip": {
-						"hideZeros": false,
-						"mode": "single",
-						"sort": "none"
-					}
-				},
-				"pluginVersion": "11.6.0",
-				"targets": [
-					{
-						"disableTextWrap": false,
-						"editorMode": "builder",
-						"expr": "rate(node_netstat_Tcp_InSegs[5m])",
-						"fullMetaSearch": false,
-						"includeNullMetadata": true,
-						"legendFormat": "In segments",
-						"range": true,
-						"refId": "A",
-						"useBackend": false
-					},
-					{
-						"datasource": {
-							"type": "prometheus"
-						},
-						"disableTextWrap": false,
-						"editorMode": "builder",
-						"expr": "rate(node_netstat_Tcp_OutSegs[5m]) * -1",
-						"fullMetaSearch": false,
-						"hide": false,
-						"includeNullMetadata": true,
-						"instant": false,
-						"legendFormat": "out segments",
-						"range": true,
-						"refId": "B",
-						"useBackend": false
-					}
-				],
-				"title": "TCP segments",
-				"type": "timeseries"
-			},
-			{
-				"datasource": {
-					"type": "prometheus"
-				},
-				"fieldConfig": {
-					"defaults": {
-						"color": {
-							"mode": "palette-classic"
-						},
-						"custom": {
-							"axisBorderShow": false,
-							"axisCenteredZero": true,
-							"axisColorMode": "text",
-							"axisLabel": "",
-							"axisPlacement": "auto",
-							"barAlignment": 0,
-							"barWidthFactor": 0.6,
-							"drawStyle": "line",
-							"fillOpacity": 0,
-							"gradientMode": "none",
-							"hideFrom": {
-								"legend": false,
-								"tooltip": false,
-								"viz": false
-							},
-							"insertNulls": false,
-							"lineInterpolation": "linear",
-							"lineWidth": 1,
-							"pointSize": 5,
-							"scaleDistribution": {
-								"type": "linear"
-							},
-							"showPoints": "auto",
-							"spanNulls": false,
-							"stacking": {
-								"group": "A",
-								"mode": "none"
-							},
-							"thresholdsStyle": {
-								"mode": "off"
-							}
-						},
-						"mappings": [],
-						"thresholds": {
-							"mode": "absolute",
-							"steps": [
-								{
-									"color": "green"
-								},
-								{
-									"color": "red",
-									"value": 80
-								}
-							]
-						}
-					},
-					"overrides": []
-				},
-				"gridPos": {
-					"h": 8,
-					"w": 12,
-					"x": 0,
-					"y": 8
-				},
-				"id": 10,
-				"options": {
-					"legend": {
-						"calcs": [],
-						"displayMode": "list",
-						"placement": "bottom",
-						"showLegend": true
-					},
-					"tooltip": {
-						"hideZeros": false,
-						"mode": "single",
-						"sort": "none"
-					}
-				},
-				"pluginVersion": "11.6.0",
-				"targets": [
-					{
-						"disableTextWrap": false,
-						"editorMode": "builder",
-						"expr": "rate(node_netstat_Udp_InDatagrams[5m])",
-						"fullMetaSearch": false,
-						"includeNullMetadata": true,
-						"legendFormat": "__auto",
-						"range": true,
-						"refId": "A",
-						"useBackend": false
-					},
-					{
-						"datasource": {
-							"type": "prometheus"
-						},
-						"disableTextWrap": false,
-						"editorMode": "builder",
-						"expr": "rate(node_netstat_Udp_OutDatagrams[5m]) * -1",
-						"fullMetaSearch": false,
-						"hide": false,
-						"includeNullMetadata": true,
-						"instant": false,
-						"legendFormat": "__auto",
-						"range": true,
-						"refId": "B",
-						"useBackend": false
-					}
-				],
-				"title": "UPD datagrams received/sent",
-				"type": "timeseries"
-			},
-			{
-				"datasource": {
-					"type": "prometheus"
-				},
-				"fieldConfig": {
-					"defaults": {
-						"color": {
-							"mode": "palette-classic"
-						},
-						"custom": {
-							"axisBorderShow": false,
-							"axisCenteredZero": false,
-							"axisColorMode": "text",
-							"axisLabel": "",
-							"axisPlacement": "auto",
-							"barAlignment": 0,
-							"barWidthFactor": 0.6,
-							"drawStyle": "line",
-							"fillOpacity": 0,
-							"gradientMode": "none",
-							"hideFrom": {
-								"legend": false,
-								"tooltip": false,
-								"viz": false
-							},
-							"insertNulls": false,
-							"lineInterpolation": "linear",
-							"lineWidth": 1,
-							"pointSize": 5,
-							"scaleDistribution": {
-								"type": "linear"
-							},
-							"showPoints": "auto",
-							"spanNulls": false,
-							"stacking": {
-								"group": "A",
-								"mode": "none"
-							},
-							"thresholdsStyle": {
-								"mode": "off"
-							}
-						},
-						"mappings": [],
-						"thresholds": {
-							"mode": "absolute",
-							"steps": [
-								{
-									"color": "green"
-								},
-								{
-									"color": "red",
-									"value": 80
-								}
-							]
-						}
-					},
-					"overrides": []
-				},
-				"gridPos": {
-					"h": 8,
-					"w": 12,
-					"x": 12,
-					"y": 8
-				},
-				"id": 8,
-				"options": {
-					"legend": {
-						"calcs": ["max", "min", "mean"],
-						"displayMode": "list",
-						"placement": "bottom",
-						"showLegend": true
-					},
-					"tooltip": {
-						"hideZeros": false,
-						"mode": "single",
-						"sort": "none"
-					}
-				},
-				"pluginVersion": "11.6.0",
-				"targets": [
-					{
-						"editorMode": "code",
-						"expr": "node_netstat_TcpExt_ListenDrops",
-						"legendFormat": "listen drops",
-						"range": true,
-						"refId": "A"
-					}
-				],
-				"title": "SYNs to LISTEN sockets ignored",
-				"type": "timeseries"
-			},
-			{
-				"datasource": {
-					"type": "prometheus"
-				},
-				"fieldConfig": {
-					"defaults": {
-						"color": {
-							"mode": "palette-classic"
-						},
-						"custom": {
-							"axisBorderShow": false,
-							"axisCenteredZero": false,
-							"axisColorMode": "text",
-							"axisLabel": "",
-							"axisPlacement": "auto",
-							"barAlignment": 0,
-							"barWidthFactor": 0.6,
-							"drawStyle": "line",
-							"fillOpacity": 0,
-							"gradientMode": "none",
-							"hideFrom": {
-								"legend": false,
-								"tooltip": false,
-								"viz": false
-							},
-							"insertNulls": false,
-							"lineInterpolation": "linear",
-							"lineWidth": 1,
-							"pointSize": 5,
-							"scaleDistribution": {
-								"type": "linear"
-							},
-							"showPoints": "auto",
-							"spanNulls": false,
-							"stacking": {
-								"group": "A",
-								"mode": "none"
-							},
-							"thresholdsStyle": {
-								"mode": "off"
-							}
-						},
-						"mappings": [],
-						"thresholds": {
-							"mode": "absolute",
-							"steps": [
-								{
-									"color": "green"
-								},
-								{
-									"color": "red",
-									"value": 80
-								}
-							]
-						}
-					},
-					"overrides": []
-				},
-				"gridPos": {
-					"h": 8,
-					"w": 12,
-					"x": 0,
-					"y": 16
-				},
-				"id": 9,
-				"options": {
-					"legend": {
-						"calcs": [],
-						"displayMode": "list",
-						"placement": "bottom",
-						"showLegend": true
-					},
-					"tooltip": {
-						"hideZeros": false,
-						"mode": "single",
-						"sort": "none"
-					}
-				},
-				"pluginVersion": "11.6.0",
-				"targets": [
-					{
-						"disableTextWrap": false,
-						"editorMode": "builder",
-						"expr": "irate(node_netstat_TcpExt_TCPSynRetrans[5m])",
-						"fullMetaSearch": false,
-						"includeNullMetadata": true,
-						"legendFormat": "__auto",
-						"range": true,
-						"refId": "A",
-						"useBackend": false
-					}
-				],
-				"title": "SYN retransmits",
-				"type": "timeseries"
-			},
-			{
-				"collapsed": false,
-				"gridPos": {
-					"h": 1,
-					"w": 24,
-					"x": 0,
-					"y": 24
-				},
-				"id": 6,
-				"panels": [],
-				"title": "Row title",
-				"type": "row"
-			},
-			{
-				"datasource": {
-					"type": "prometheus"
-				},
-				"fieldConfig": {
-					"defaults": {
-						"color": {
-							"mode": "palette-classic"
-						},
-						"custom": {
-							"axisBorderShow": false,
-							"axisCenteredZero": false,
-							"axisColorMode": "text",
-							"axisLabel": "",
-							"axisPlacement": "auto",
-							"barAlignment": 0,
-							"barWidthFactor": 0.6,
-							"drawStyle": "line",
-							"fillOpacity": 0,
-							"gradientMode": "none",
-							"hideFrom": {
-								"legend": false,
-								"tooltip": false,
-								"viz": false
-							},
-							"insertNulls": false,
-							"lineInterpolation": "linear",
-							"lineWidth": 1,
-							"pointSize": 5,
-							"scaleDistribution": {
-								"type": "linear"
-							},
-							"showPoints": "auto",
-							"spanNulls": false,
-							"stacking": {
-								"group": "A",
-								"mode": "none"
-							},
-							"thresholdsStyle": {
-								"mode": "off"
-							}
-						},
-						"mappings": [],
-						"thresholds": {
-							"mode": "absolute",
-							"steps": [
-								{
-									"color": "green"
-								},
-								{
-									"color": "red",
-									"value": 80
-								}
-							]
-						}
-					},
-					"overrides": []
-				},
-				"gridPos": {
-					"h": 8,
-					"w": 12,
-					"x": 0,
-					"y": 25
-				},
-				"id": 5,
-				"options": {
-					"legend": {
-						"calcs": [],
-						"displayMode": "list",
-						"placement": "bottom",
-						"showLegend": true
-					},
-					"tooltip": {
-						"hideZeros": false,
-						"mode": "single",
-						"sort": "none"
-					}
-				},
-				"pluginVersion": "11.6.0",
-				"targets": [
-					{
-						"editorMode": "code",
-						"expr": "node_sockstat_sockets_used",
-						"legendFormat": "{{name}}",
-						"range": true,
-						"refId": "A"
-					}
-				],
-				"title": "Socket usage",
-				"type": "timeseries"
-			},
-			{
-				"id": 7,
-				"type": "timeseries",
-				"title": "Netstat octets",
-				"gridPos": {
-					"x": 12,
-					"y": 25,
-					"h": 8,
-					"w": 12
-				},
-				"fieldConfig": {
-					"defaults": {
-						"custom": {
-							"drawStyle": "line",
-							"lineInterpolation": "linear",
-							"barAlignment": 0,
-							"barWidthFactor": 0.6,
-							"lineWidth": 1,
-							"fillOpacity": 0,
-							"gradientMode": "none",
-							"spanNulls": false,
-							"insertNulls": false,
-							"showPoints": "auto",
-							"pointSize": 5,
-							"stacking": {
-								"mode": "none",
-								"group": "A"
-							},
-							"axisPlacement": "auto",
-							"axisLabel": "",
-							"axisColorMode": "text",
-							"axisBorderShow": false,
-							"scaleDistribution": {
-								"type": "linear"
-							},
-							"axisCenteredZero": true,
-							"hideFrom": {
-								"tooltip": false,
-								"viz": false,
-								"legend": false
-							},
-							"thresholdsStyle": {
-								"mode": "off"
-							}
-						},
-						"color": {
-							"mode": "palette-classic"
-						},
-						"mappings": [],
-						"thresholds": {
-							"mode": "absolute",
-							"steps": [
-								{
-									"color": "green",
-									"value": null
-								},
-								{
-									"color": "red",
-									"value": 80
-								}
-							]
-						},
-						"unit": "decbytes"
-					},
-					"overrides": []
-				},
-				"pluginVersion": "11.6.0",
-				"targets": [
-					{
-						"disableTextWrap": false,
-						"editorMode": "code",
-						"expr": "irate(node_netstat_IpExt_InOctets[5m])",
-						"format": "time_series",
-						"fullMetaSearch": false,
-						"includeNullMetadata": true,
-						"legendFormat": "octets in",
-						"range": true,
-						"refId": "A",
-						"useBackend": false
-					},
-					{
-						"datasource": {
-							"type": "prometheus"
-						},
-						"disableTextWrap": false,
-						"editorMode": "code",
-						"expr": "- irate(node_netstat_IpExt_OutOctets[5m])",
-						"fullMetaSearch": false,
-						"hide": false,
-						"includeNullMetadata": true,
-						"instant": false,
-						"legendFormat": "octets out",
-						"range": true,
-						"refId": "B",
-						"useBackend": false
-					}
-				],
-				"datasource": {
-					"type": "prometheus"
-				},
-				"options": {
-					"tooltip": {
-						"mode": "single",
-						"sort": "none",
-						"hideZeros": false
-					},
-					"legend": {
-						"showLegend": true,
-						"displayMode": "list",
-						"placement": "bottom",
-						"calcs": []
-					}
-				}
-			},
-			{
-				"datasource": {
-					"type": "prometheus"
-				},
-				"fieldConfig": {
-					"defaults": {
-						"color": {
-							"mode": "palette-classic"
-						},
-						"custom": {
-							"axisBorderShow": false,
-							"axisCenteredZero": false,
-							"axisColorMode": "text",
-							"axisLabel": "",
-							"axisPlacement": "auto",
-							"barAlignment": 0,
-							"barWidthFactor": 0.6,
-							"drawStyle": "line",
-							"fillOpacity": 0,
-							"gradientMode": "none",
-							"hideFrom": {
-								"legend": false,
-								"tooltip": false,
-								"viz": false
-							},
-							"insertNulls": false,
-							"lineInterpolation": "linear",
-							"lineWidth": 1,
-							"pointSize": 5,
-							"scaleDistribution": {
-								"type": "linear"
-							},
-							"showPoints": "auto",
-							"spanNulls": false,
-							"stacking": {
-								"group": "A",
-								"mode": "none"
-							},
-							"thresholdsStyle": {
-								"mode": "off"
-							}
-						},
-						"mappings": [],
-						"thresholds": {
-							"mode": "absolute",
-							"steps": [
-								{
-									"color": "green"
-								},
-								{
-									"color": "red",
-									"value": 80
-								}
-							]
-						}
-					},
-					"overrides": []
-				},
-				"gridPos": {
-					"h": 8,
-					"w": 12,
-					"x": 0,
-					"y": 33
-				},
-				"id": 1,
-				"options": {
-					"legend": {
-						"calcs": ["min", "max", "median"],
-						"displayMode": "list",
-						"placement": "bottom",
-						"showLegend": true
-					},
-					"tooltip": {
-						"hideZeros": false,
-						"mode": "single",
-						"sort": "none"
-					}
-				},
-				"pluginVersion": "11.6.0",
-				"targets": [
-					{
-						"datasource": {
-							"type": "prometheus"
-						},
-						"editorMode": "code",
-						"expr": "node_sockstat_TCP_alloc",
-						"instant": false,
-						"legendFormat": "allocated TCP sockets",
-						"range": true,
-						"refId": "A"
-					},
-					{
-						"datasource": {
-							"type": "prometheus"
-						},
-						"editorMode": "code",
-						"expr": "node_sockstat_TCP_inuse",
-						"hide": false,
-						"instant": false,
-						"legendFormat": "TCP sockets in use",
-						"range": true,
-						"refId": "B"
-					}
-				],
-				"title": "TCP sockets",
-				"type": "timeseries"
-			},
-			{
-				"datasource": {
-					"type": "prometheus"
-				},
-				"fieldConfig": {
-					"defaults": {
-						"color": {
-							"mode": "palette-classic"
-						},
-						"custom": {
-							"axisBorderShow": false,
-							"axisCenteredZero": false,
-							"axisColorMode": "text",
-							"axisLabel": "",
-							"axisPlacement": "auto",
-							"barAlignment": 0,
-							"barWidthFactor": 0.6,
-							"drawStyle": "line",
-							"fillOpacity": 0,
-							"gradientMode": "none",
-							"hideFrom": {
-								"legend": false,
-								"tooltip": false,
-								"viz": false
-							},
-							"insertNulls": false,
-							"lineInterpolation": "linear",
-							"lineWidth": 1,
-							"pointSize": 5,
-							"scaleDistribution": {
-								"type": "linear"
-							},
-							"showPoints": "auto",
-							"spanNulls": false,
-							"stacking": {
-								"group": "A",
-								"mode": "none"
-							},
-							"thresholdsStyle": {
-								"mode": "off"
-							}
-						},
-						"mappings": [],
-						"thresholds": {
-							"mode": "absolute",
-							"steps": [
-								{
-									"color": "green"
-								},
-								{
-									"color": "red",
-									"value": 80
-								}
-							]
-						},
-						"unit": "decbytes"
-					},
-					"overrides": []
-				},
-				"gridPos": {
-					"h": 8,
-					"w": 12,
-					"x": 12,
-					"y": 33
-				},
-				"id": 2,
-				"options": {
-					"legend": {
-						"calcs": ["min", "median", "max"],
-						"displayMode": "list",
-						"placement": "bottom",
-						"showLegend": true
-					},
-					"tooltip": {
-						"hideZeros": false,
-						"mode": "single",
-						"sort": "none"
-					}
-				},
-				"pluginVersion": "11.6.0",
-				"targets": [
-					{
-						"editorMode": "code",
-						"expr": "node_sockstat_TCP_mem_bytes",
-						"legendFormat": "__auto",
-						"range": true,
-						"refId": "A"
-					}
-				],
-				"title": "TCP memory usage",
-				"type": "timeseries"
-			},
-			{
-				"datasource": {
-					"type": "prometheus"
-				},
-				"fieldConfig": {
-					"defaults": {
-						"color": {
-							"mode": "palette-classic"
-						},
-						"custom": {
-							"axisBorderShow": false,
-							"axisCenteredZero": false,
-							"axisColorMode": "text",
-							"axisLabel": "",
-							"axisPlacement": "auto",
-							"barAlignment": 0,
-							"barWidthFactor": 0.6,
-							"drawStyle": "line",
-							"fillOpacity": 0,
-							"gradientMode": "none",
-							"hideFrom": {
-								"legend": false,
-								"tooltip": false,
-								"viz": false
-							},
-							"insertNulls": false,
-							"lineInterpolation": "linear",
-							"lineWidth": 1,
-							"pointSize": 5,
-							"scaleDistribution": {
-								"type": "linear"
-							},
-							"showPoints": "auto",
-							"spanNulls": false,
-							"stacking": {
-								"group": "A",
-								"mode": "none"
-							},
-							"thresholdsStyle": {
-								"mode": "off"
-							}
-						},
-						"mappings": [],
-						"thresholds": {
-							"mode": "absolute",
-							"steps": [
-								{
-									"color": "green"
-								},
-								{
-									"color": "red",
-									"value": 80
-								}
-							]
-						}
-					},
-					"overrides": []
-				},
-				"gridPos": {
-					"h": 8,
-					"w": 12,
-					"x": 0,
-					"y": 41
-				},
-				"id": 3,
-				"options": {
-					"legend": {
-						"calcs": [],
-						"displayMode": "list",
-						"placement": "bottom",
-						"showLegend": true
-					},
-					"tooltip": {
-						"hideZeros": false,
-						"mode": "single",
-						"sort": "none"
-					}
-				},
-				"pluginVersion": "11.6.0",
-				"targets": [
-					{
-						"editorMode": "code",
-						"expr": "node_sockstat_UDPLITE_inuse + node_sockstat_UDP_inuse",
-						"legendFormat": "UDP + UDPLITE sockets in use",
-						"range": true,
-						"refId": "A"
-					}
-				],
-				"title": "UPD socket usage",
-				"type": "timeseries"
-			},
-			{
-				"datasource": {
-					"type": "prometheus"
-				},
-				"fieldConfig": {
-					"defaults": {
-						"color": {
-							"mode": "palette-classic"
-						},
-						"custom": {
-							"axisBorderShow": false,
-							"axisCenteredZero": false,
-							"axisColorMode": "text",
-							"axisLabel": "",
-							"axisPlacement": "auto",
-							"barAlignment": 0,
-							"barWidthFactor": 0.6,
-							"drawStyle": "line",
-							"fillOpacity": 0,
-							"gradientMode": "none",
-							"hideFrom": {
-								"legend": false,
-								"tooltip": false,
-								"viz": false
-							},
-							"insertNulls": false,
-							"lineInterpolation": "linear",
-							"lineWidth": 1,
-							"pointSize": 5,
-							"scaleDistribution": {
-								"type": "linear"
-							},
-							"showPoints": "auto",
-							"spanNulls": false,
-							"stacking": {
-								"group": "A",
-								"mode": "none"
-							},
-							"thresholdsStyle": {
-								"mode": "off"
-							}
-						},
-						"mappings": [],
-						"thresholds": {
-							"mode": "absolute",
-							"steps": [
-								{
-									"color": "green"
-								},
-								{
-									"color": "red",
-									"value": 80
-								}
-							]
-						},
-						"unit": "decbytes"
-					},
-					"overrides": []
-				},
-				"gridPos": {
-					"h": 8,
-					"w": 12,
-					"x": 12,
-					"y": 41
-				},
-				"id": 4,
-				"options": {
-					"legend": {
-						"calcs": [],
-						"displayMode": "list",
-						"placement": "bottom",
-						"showLegend": true
-					},
-					"tooltip": {
-						"hideZeros": false,
-						"mode": "single",
-						"sort": "none"
-					}
-				},
-				"pluginVersion": "11.6.0",
-				"targets": [
-					{
-						"editorMode": "code",
-						"expr": "node_sockstat_UDP_mem",
-						"legendFormat": "__auto",
-						"range": true,
-						"refId": "A"
-					}
-				],
-				"title": "UDP sockets memory usage ",
-				"type": "timeseries"
-			}
-		],
-		"preload": false,
-		"schemaVersion": 41,
-		"tags": ["network_monitor"],
-		"templating": {
-			"list": []
-		},
-		"time": {
-			"from": "now-30m",
-			"to": "now"
-		},
-		"timepicker": {},
-		"timezone": "browser",
-		"title": "Network",
-		"uid": null
-	},
-	"overwrite": true
+  "dashboard": {
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": null,
+    "links": [],
+    "panels": [
+      {
+        "datasource": {
+          "type": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 12,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.6.0",
+        "targets": [
+          {
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "expr": "irate(node_netstat_Tcp_ActiveOpens[5m])",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "legendFormat": "TCP active connections",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          },
+          {
+            "datasource": {
+              "type": "prometheus"
+            },
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "expr": "irate(node_netstat_Tcp_PassiveOpens[5m])",
+            "fullMetaSearch": false,
+            "hide": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "TCP passive connections",
+            "range": true,
+            "refId": "B",
+            "useBackend": false
+          }
+        ],
+        "title": "TCP active/passive connections",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 0
+        },
+        "id": 11,
+        "options": {
+          "legend": {
+            "calcs": ["min", "max", "mean"],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.6.0",
+        "targets": [
+          {
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "expr": "rate(node_netstat_Tcp_InSegs[5m])",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "legendFormat": "In segments",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          },
+          {
+            "datasource": {
+              "type": "prometheus"
+            },
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "expr": "rate(node_netstat_Tcp_OutSegs[5m]) * -1",
+            "fullMetaSearch": false,
+            "hide": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "out segments",
+            "range": true,
+            "refId": "B",
+            "useBackend": false
+          }
+        ],
+        "title": "TCP segments",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": true,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 8
+        },
+        "id": 10,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.6.0",
+        "targets": [
+          {
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "expr": "rate(node_netstat_Udp_InDatagrams[5m])",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          },
+          {
+            "datasource": {
+              "type": "prometheus"
+            },
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "expr": "rate(node_netstat_Udp_OutDatagrams[5m]) * -1",
+            "fullMetaSearch": false,
+            "hide": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "B",
+            "useBackend": false
+          }
+        ],
+        "title": "UPD Datagrams received/sent",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 8
+        },
+        "id": 8,
+        "options": {
+          "legend": {
+            "calcs": ["max", "min", "mean"],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.6.0",
+        "targets": [
+          {
+            "editorMode": "code",
+            "expr": "node_netstat_TcpExt_ListenDrops",
+            "legendFormat": "listen drops",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "SYNs to LISTEN sockets ignored",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 16
+        },
+        "id": 9,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.6.0",
+        "targets": [
+          {
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "expr": "irate(node_netstat_TcpExt_TCPSynRetrans[5m])",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "SYN retransmits",
+        "type": "timeseries"
+      },
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 24
+        },
+        "id": 6,
+        "panels": [],
+        "title": "Row title",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 25
+        },
+        "id": 5,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.6.0",
+        "targets": [
+          {
+            "editorMode": "code",
+            "expr": "node_sockstat_sockets_used",
+            "legendFormat": "{{name}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Socket usage",
+        "type": "timeseries"
+      },
+      {
+        "id": 7,
+        "type": "timeseries",
+        "title": "Netstat octets",
+        "gridPos": {
+          "x": 12,
+          "y": 25,
+          "h": 8,
+          "w": 12
+        },
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "drawStyle": "line",
+              "lineInterpolation": "linear",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "lineWidth": 1,
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "spanNulls": false,
+              "insertNulls": false,
+              "showPoints": "auto",
+              "pointSize": 5,
+              "stacking": {
+                "mode": "none",
+                "group": "A"
+              },
+              "axisPlacement": "auto",
+              "axisLabel": "",
+              "axisColorMode": "text",
+              "axisBorderShow": false,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "axisCenteredZero": true,
+              "hideFrom": {
+                "tooltip": false,
+                "viz": false,
+                "legend": false
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "color": {
+              "mode": "palette-classic"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "decbytes"
+          },
+          "overrides": []
+        },
+        "pluginVersion": "11.6.0",
+        "targets": [
+          {
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "expr": "irate(node_netstat_IpExt_InOctets[5m])",
+            "format": "time_series",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "legendFormat": "octets in",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          },
+          {
+            "datasource": {
+              "type": "prometheus"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "expr": "- irate(node_netstat_IpExt_OutOctets[5m])",
+            "fullMetaSearch": false,
+            "hide": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "octets out",
+            "range": true,
+            "refId": "B",
+            "useBackend": false
+          }
+        ],
+        "datasource": {
+          "type": "prometheus"
+        },
+        "options": {
+          "tooltip": {
+            "mode": "single",
+            "sort": "none",
+            "hideZeros": false
+          },
+          "legend": {
+            "showLegend": true,
+            "displayMode": "list",
+            "placement": "bottom",
+            "calcs": []
+          }
+        }
+      },
+      {
+        "datasource": {
+          "type": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 33
+        },
+        "id": 1,
+        "options": {
+          "legend": {
+            "calcs": ["min", "max", "median"],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.6.0",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "node_sockstat_TCP_alloc",
+            "instant": false,
+            "legendFormat": "allocated TCP sockets",
+            "range": true,
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "node_sockstat_TCP_inuse",
+            "hide": false,
+            "instant": false,
+            "legendFormat": "TCP sockets in use",
+            "range": true,
+            "refId": "B"
+          }
+        ],
+        "title": "TCP sockets",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "decbytes"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 33
+        },
+        "id": 2,
+        "options": {
+          "legend": {
+            "calcs": ["min", "median", "max"],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.6.0",
+        "targets": [
+          {
+            "editorMode": "code",
+            "expr": "node_sockstat_TCP_mem_bytes",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "TCP memory usage",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 41
+        },
+        "id": 3,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.6.0",
+        "targets": [
+          {
+            "editorMode": "code",
+            "expr": "node_sockstat_UDPLITE_inuse + node_sockstat_UDP_inuse",
+            "legendFormat": "UDP + UDPLITE sockets in use",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "UPD socket usage",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "decbytes"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 41
+        },
+        "id": 4,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.6.0",
+        "targets": [
+          {
+            "editorMode": "code",
+            "expr": "node_sockstat_UDP_mem",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "UDP sockets memory usage ",
+        "type": "timeseries"
+      }
+    ],
+    "preload": false,
+    "schemaVersion": 41,
+    "tags": ["network_monitor"],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-30m",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "browser",
+    "title": "Network",
+    "uid": null
+  },
+  "overwrite": true
 }


### PR DESCRIPTION
# 🧩 Miscellaneous Pull Request

---

## 📄 Description

This PR fixes some spelling mikstakes in MONITORING
- endpoints_availability.json: "title": "Average respose time" It should be "response"
- network_monitor.json: "title": "UPD datagrams received/sent" It should be "Datagram" (upercased proper noun)

---

## 📦 Affected Modules

MONITORING

---

## 🔍 Examples

- Corrected `endpoints_availability.json` and `network_monitor.json`

---

## 📚 Categories (check all that apply)

- [ ] CI/CD configuration.
- [ ] GitHub templates or workflows.
- [ ] Documentation not covered by docs template.
- [ ] Build scripts or Makefile tweaks.
- [X] Other (explain): Spelling mistakes in json files.

---

## ✅ Checklist

- [X] Non-code or non-feature logic.
- [X] Doesn’t affect runtime or production behavior.
- [X] All changes are documented (where relevant).
- [X] Change is out-of-scope for feature/bugfix/docs/refactor/style/breaking.
- [ ] Tests updated or added (if applicable).
- [X] CI passes.
- [ ] Relevant team members informed. :hand_over_mouth: (_the daemon/linter that runs manually LITERALLY_)

---

## 📸 Screenshots/Links (if applicable)

Sorry! I don't have **Before** pictures.
- [Network Dashboard](https://cdn.discordapp.com/attachments/1379542926320734258/1379542929890345090/Screenshot_from_2025-06-03_21-17-27.png?ex=68409ef9&is=683f4d79&hm=926934337e7e2066852db09d35828f0b45dc1f725287f5773100f5de4f1e3c9e&)
- [Endpoints Availability Dashbiard](https://cdn.discordapp.com/attachments/1379542926320734258/1379542943261786303/Screenshot_from_2025-06-03_21-18-15.png?ex=68409efc&is=683f4d7c&hm=cb8acba308de2fd812553ae027f33ef9bb353446f7eac8084d4311a412f39bd9&)